### PR TITLE
Bump org.kde.Platform version to 6.8

### DIFF
--- a/org.pencil2d.Pencil2D.yaml
+++ b/org.pencil2d.Pencil2D.yaml
@@ -1,7 +1,7 @@
 app-id: org.pencil2d.Pencil2D
 default-branch: stable
 runtime: org.kde.Platform
-runtime-version: '6.7'
+runtime-version: '6.8'
 sdk: org.kde.Sdk
 command: pencil2d
 finish-args:


### PR DESCRIPTION
It appears this is necessary to fix Pencil2D failing to start with XWayland. Running the Pencil2D Flatpak with `QT_QPA_PLATFORM=xcb` on Wayland (Debian 11.11.0 Gnome) results in an error such as:
```
qt.qpa.xcb: could not connect to display 
qt.qpa.plugin: From 6.5.0, xcb-cursor0 or libxcb-cursor0 is needed to load the Qt xcb platform plugin.
qt.qpa.plugin: Could not load the Qt platform plugin "xcb" in "" even though it was found.
This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.

Available platform plugins are: eglfs, linuxfb, minimal, minimalegl, offscreen, vkkhrdisplay, vnc, wayland-egl, wayland, xcb.
```
as reported by a user [here](https://discuss.pencil2d.org/t/cant-install-using-flatpak/9516/5).

Unfortunately I was not able to reproduce their other crash with Wayland, but a newer version of Qt may help with that too.